### PR TITLE
Fix bug on link to tree page. Reason: recipe.id instead of recipe._id

### DIFF
--- a/client/src/components/Recipe/index.jsx
+++ b/client/src/components/Recipe/index.jsx
@@ -38,13 +38,12 @@ export default function RecipeComponent({ recipeId }) {
                   <button className="bg-red-500" onClick={() => setToggleForm(!toggleForm)}>
                     Fork
                   </button>
-                  {recipe.path && (
-                    <span className="bg-red-500">
-                      <Link to={`${ROUTES.VERSIONS}/${recipe.path ? recipe.path[0] : recipe._id}`}>
-                        Other Forks
-                      </Link>
-                    </span>
-                  )}
+
+                  <span className="bg-red-500">
+                    <Link to={`${ROUTES.VERSIONS}/${!recipe.parent ? recipe._id : recipe.path[0]}`}>
+                      Other Forks
+                    </Link>
+                  </span>
                 </div>
               </div>
               <div className="flex container bg-yellow-500">

--- a/client/src/components/Versions/index.jsx
+++ b/client/src/components/Versions/index.jsx
@@ -3,7 +3,6 @@ import TreeContainer from './TreeContainer';
 import { useParams } from 'react-router-dom';
 export default function VersionComponent() {
   const { id } = useParams();
-  console.log('VERSION id: ', id);
   return (
     <div className="flex-row mx-auto container pt-8">
       <div className="flex justify-between content-start space-x-6 bg-green-500">


### PR DESCRIPTION
Fix typo that caused major bug with linking to tree visual pages