### PR TITLE
Fix/tree card

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -13,8 +13,8 @@ const Navbar = ({ transparent }) => {
 
   // For demo purposes
   const demoUsers = {
-    '61e607f0311d699fd35f509e': 'JoeMics',
-    '61e608607f04825b4c4cd517': 'IvanTang',
+    '61e607f0311d699fd35f509e': 'Joseph Micla',
+    '61e608607f04825b4c4cd517': 'Ivan Tang',
   };
 
   // For demo purposes
@@ -76,7 +76,7 @@ const Navbar = ({ transparent }) => {
           className="block items-center px-4 py-2 text-xl dark:text-neutral-200"
           onClick={cycleUsers}
         >
-          Demo: {demoUsers[userId]}
+          {demoUsers[userId]}
         </button>
         <Toggle />
       </div>

--- a/client/src/components/Versions/Tree.jsx
+++ b/client/src/components/Versions/Tree.jsx
@@ -130,7 +130,11 @@ export default function OrgChartTree({ treeId }) {
                 </Link>
 
                 <span
-                  className="flex justify-center basis-1/3 grow border-stone-300  border-x hover:bg-stone-200 dark:hover:bg-dark-700 group-hover:transition-all duration-300"
+                  className={
+                    nodeDatum.children
+                      ? 'flex justify-center basis-1/3 grow border-stone-300  border-x hover:bg-stone-200 dark:hover:bg-dark-700 group-hover:transition-all duration-300'
+                      : 'flex justify-center basis-1/3 grow border-stone-300  border-l rounded-br-md hover:bg-stone-200 dark:hover:bg-dark-700 group-hover:transition-all duration-300'
+                  }
                   onClick={() => handleFork(nodeDatum.recipe)}
                 >
                   <button className="flex py-2">

--- a/client/src/pages/RecipeMaster.jsx
+++ b/client/src/pages/RecipeMaster.jsx
@@ -21,9 +21,9 @@ const RecipeMaster = () => {
       setRecipes(dbData.data);
       // it loads too fast to see at the moment, so this will be removed in
       //real app and we just have setLoading(false);
-      setTimeout(() => setLoading(false), 1000);
+      // setTimeout(() => setLoading(false), 1000);
     }
-    setLoading(true);
+    setLoading(false);
     getRecipeData();
   }, []);
 


### PR DESCRIPTION
Fixes the react conditional button render on the tree card. Used to show 3 buttons despite not having forked recipes, now shows only 2 buttons when no children nodes, and properly generates CSS depending on the presence of the third button.